### PR TITLE
Fix broken module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 #   include textual
 class textual {
-  package { 'Textual-4.1.5':
+  package { 'Textual':
     source   => 'https://d3pep6299hwdsh.cloudfront.net/puppet-textual/Textual-4.1.5.zip',
     provider => 'compressed_app'
   }

--- a/spec/classes/textual_spec.rb
+++ b/spec/classes/textual_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'textual' do
   it do
-    should contain_package('Textual-4.1.5').with({
+    should contain_package('Textual').with({
       :source   => 'https://d3pep6299hwdsh.cloudfront.net/puppet-textual/Textual-4.1.5.zip',
       :provider => 'compressed_app',
     })


### PR DESCRIPTION
This module was broken on version 4.1.5:

`Error: Execution of '/usr/sbin/chown -R fromonesrc:staff /Applications/Textual-4.1.5.app' returned 1: chown: /Applications/Textual-4.1.5.app: No such file or directory`

This fixes the bad package name and spec.

Also will be releasing a 4.2.0. @bbck just a heads up we are using [semver](http://semver.org/) and the version numbers for releases on this module do not (should not) need to match up with released versions of Textual.app. 
